### PR TITLE
Add export functionality

### DIFF
--- a/CodeSearcher.Index/CodeSearcherLogic.cs
+++ b/CodeSearcher.Index/CodeSearcherLogic.cs
@@ -7,9 +7,8 @@ using CodeSearcher.Interfaces;
 
 namespace CodeSearcher.BusinessLogic
 {
-    public class CodeSearcherLogic
+    public class CodeSearcherLogic : ICodeSearcherLogic
     {
-        private readonly ICmdLineHandler m_CmdHandler;
         private readonly ICodeSearcherLogger m_Logger;
         private static long m_FileCounter;
         private readonly Func<string> m_GetIndexPath;
@@ -17,13 +16,11 @@ namespace CodeSearcher.BusinessLogic
         private readonly Func<IList<string>> m_GetFileExtension;
 
         public CodeSearcherLogic(
-            ICmdLineHandler cmdHandler,
             ICodeSearcherLogger logger,
             Func<string> getIndexPath,
             Func<string> getSourcePath,
             Func<IList<string>> getFileExtension)
         {
-            m_CmdHandler = cmdHandler;
             m_Logger = logger;
             m_GetIndexPath = getIndexPath;
             m_GetSourcePath = getSourcePath;
@@ -31,8 +28,8 @@ namespace CodeSearcher.BusinessLogic
         }
 
         public void CreateNewIndex(
-            Action startCallback, 
-            Action<string> fileProccessedCallback, 
+            Action startCallback,
+            Action<string> fileProccessedCallback,
             Action<long, TimeSpan> finishedCallback)
         {
             startCallback();
@@ -63,7 +60,7 @@ namespace CodeSearcher.BusinessLogic
         {
             var sw = new Stopwatch();
             m_Logger.Debug("> start running action: {0}", name);
-            
+
             sw.Start();
             action();
             sw.Stop();
@@ -85,67 +82,52 @@ namespace CodeSearcher.BusinessLogic
         }
 
         public void SearchWithinExistingIndex(
-            Action startCallback, 
+            Action startCallback,
             Func<(string, bool)> getSearchWord,
-            ISingleResultPrinter printer,
+            Func<int> getMaximumNumberOfHits,
+            Func<int> getHitsPerPage,
+            Func<(bool, StreamWriter)> getExporter,
+            Func<ISingleResultPrinter> getSingleResultPrinter,
             Action<TimeSpan> finishedCallback,
             Action endOfSearchCallback,
-            Action<string> exportFinishedCallback = null)
+            Action exportFinishedCallback = null)
         {
             startCallback();
-            
+
             var idxPath = m_GetIndexPath();
 
-            using(var searcher = Factory.GetSearcher(idxPath))
+            using (var searcher = Factory.GetSearcher(idxPath))
             {
+                int numberOfHits = getMaximumNumberOfHits();
+                int hitsPerPage = getHitsPerPage();
+                (bool export, StreamWriter exportWriter) = getExporter();
+                var printer = getSingleResultPrinter();
+
                 do
                 {
                     (string searchedWord, bool shouldExit) = getSearchWord();
                     if (string.IsNullOrWhiteSpace(searchedWord) && shouldExit) break;
-
-					int numberOfHits;
-
-					if (!int.TryParse(m_CmdHandler[m_CmdHandler.NumberOfHits], out numberOfHits))
-					{
-						m_Logger.Info("Maximum hits to show will be 1000");
-						numberOfHits = 1000;
-					}
-
-					int hitsPerPage;
-					if (!int.TryParse(m_CmdHandler[m_CmdHandler.HitsPerPage], out hitsPerPage))
-					{
-                        m_Logger.Info("Maximum hits per page will be shown");
-                        hitsPerPage = -1;
-                    }
-
-                    bool export;
-                    if (!bool.TryParse(m_CmdHandler[m_CmdHandler.ExportToFile], out export))
-                    {
-                        m_Logger.Info("Results will not be exported");
-                        export = false;
-                    }
 
                     var timeSpan = RunActionWithTimings("Search For " + searchedWord, () =>
                     {
                         searcher.SearchFileContent(searchedWord, numberOfHits, (searchResultContainer) =>
                         {
                             m_Logger.Info("Found {0} hits", searchResultContainer.NumberOfHits);
-                            foreach(var result in searchResultContainer)
+                            foreach (var result in searchResultContainer)
                             {
                                 printer.NumbersToShow = hitsPerPage == -1
-									? int.MaxValue
-									: hitsPerPage;
+                                    ? int.MaxValue
+                                    : hitsPerPage;
 
                                 printer.Print(result.FileName, searchedWord);
                             }
 
                             if (export)
                             {
-                                var exportFile = Path.GetTempFileName();
                                 var exporter = Factory.GetResultExporter();
-                                exporter.Export(searchResultContainer, exportFile, searchedWord);
+                                exporter.Export(searchResultContainer, searchedWord, exportWriter);
 
-                                if (exportFinishedCallback != null) exportFinishedCallback(exportFile);
+                                exportFinishedCallback?.Invoke();
                             }
                         });
                     });
@@ -156,7 +138,7 @@ namespace CodeSearcher.BusinessLogic
 
                     endOfSearchCallback();
 
-                } while(true);
+                } while (true);
             }
         }
     }

--- a/CodeSearcher.Index/CodeSearcherLogic.cs
+++ b/CodeSearcher.Index/CodeSearcherLogic.cs
@@ -7,7 +7,7 @@ using CodeSearcher.Interfaces;
 
 namespace CodeSearcher.BusinessLogic
 {
-    public class CodeSearcherLogic : ICodeSearcherLogic
+    internal class CodeSearcherLogic : ICodeSearcherLogic
     {
         private readonly ICodeSearcherLogger m_Logger;
         private static long m_FileCounter;
@@ -86,7 +86,7 @@ namespace CodeSearcher.BusinessLogic
             Func<(string, bool)> getSearchWord,
             Func<int> getMaximumNumberOfHits,
             Func<int> getHitsPerPage,
-            Func<(bool, StreamWriter)> getExporter,
+            Func<(bool, IResultExporter)> getExporter,
             Func<ISingleResultPrinter> getSingleResultPrinter,
             Action<TimeSpan> finishedCallback,
             Action endOfSearchCallback,
@@ -100,7 +100,7 @@ namespace CodeSearcher.BusinessLogic
             {
                 int numberOfHits = getMaximumNumberOfHits();
                 int hitsPerPage = getHitsPerPage();
-                (bool export, StreamWriter exportWriter) = getExporter();
+                (bool export, IResultExporter resultExporter) = getExporter();
                 var printer = getSingleResultPrinter();
 
                 do
@@ -124,8 +124,8 @@ namespace CodeSearcher.BusinessLogic
 
                             if (export)
                             {
-                                var exporter = Factory.GetResultExporter();
-                                exporter.Export(searchResultContainer, searchedWord, exportWriter);
+                                
+                                resultExporter.Export(searchResultContainer, searchedWord);
 
                                 exportFinishedCallback?.Invoke();
                             }

--- a/CodeSearcher.Index/Exporter/ResultExporter.cs
+++ b/CodeSearcher.Index/Exporter/ResultExporter.cs
@@ -5,23 +5,19 @@ namespace CodeSearcher.BusinessLogic.Exporter
 {
     internal class ResultFileExporter : IResultExporter
     {
-        public void Export(ISearchResultContainer searchResultContainer, string exportFileName, string searchedWord)
+        public void Export(ISearchResultContainer searchResultContainer, string searchedWord, StreamWriter exportWriter)
         {
-            using (var writer = File.CreateText(exportFileName))
+            foreach (var result in searchResultContainer)
             {
-                foreach (var result in searchResultContainer)
+                exportWriter.WriteLine(result.FileName);
+                var lines = File.ReadAllLines(result.FileName);
+
+                for (int i = 0; i < lines.Length; i++)
                 {
-                    writer.WriteLine(result.FileName);
-                    var lines = File.ReadAllLines(result.FileName);
-
-                    for (int i = 0; i < lines.Length; i++)
+                    if (lines[i].Contains(searchedWord))
                     {
-                        if (lines[i].Contains(searchedWord))
-                        {
-                            writer.Write($"{i + 1};{lines[i]}");
-                        }
+                        exportWriter.Write($"{i + 1};{lines[i]}");
                     }
-
                 }
             }
         }

--- a/CodeSearcher.Index/Exporter/ResultExporter.cs
+++ b/CodeSearcher.Index/Exporter/ResultExporter.cs
@@ -3,23 +3,35 @@ using CodeSearcher.Interfaces;
 
 namespace CodeSearcher.BusinessLogic.Exporter
 {
-    internal class ResultFileExporter : IResultExporter
+    internal sealed class ResultFileExporter : IResultExporter
     {
-        public void Export(ISearchResultContainer searchResultContainer, string searchedWord, StreamWriter exportWriter)
+        private readonly StreamWriter m_ExportWriter;
+
+        public ResultFileExporter(StreamWriter exportWriter)
+        {
+            m_ExportWriter = exportWriter;
+        }
+
+        public void Export(ISearchResultContainer searchResultContainer, string searchedWord)
         {
             foreach (var result in searchResultContainer)
             {
-                exportWriter.WriteLine(result.FileName);
+                m_ExportWriter.WriteLine(result.FileName);
                 var lines = File.ReadAllLines(result.FileName);
 
                 for (int i = 0; i < lines.Length; i++)
                 {
                     if (lines[i].Contains(searchedWord))
                     {
-                        exportWriter.Write($"{i + 1};{lines[i]}");
+                        m_ExportWriter.WriteLine($"{i + 1};{lines[i]}");
                     }
                 }
             }
+        }
+
+        public void Dispose()
+        {
+            m_ExportWriter?.Close();
         }
     }
 }

--- a/CodeSearcher.Index/Exporter/ResultExporter.cs
+++ b/CodeSearcher.Index/Exporter/ResultExporter.cs
@@ -18,14 +18,15 @@ namespace CodeSearcher.BusinessLogic.Exporter
             {
                 m_ExportWriter.WriteLine(result.FileName);
                 var lines = File.ReadAllLines(result.FileName);
-
+                var searchWordLower = searchedWord.ToLowerInvariant();
                 for (int i = 0; i < lines.Length; i++)
                 {
-                    if (lines[i].Contains(searchedWord))
+                    if (lines[i].ToLowerInvariant().Contains(searchWordLower))
                     {
                         m_ExportWriter.WriteLine($"{i + 1};{lines[i]}");
                     }
                 }
+                m_ExportWriter.Flush();
             }
         }
 

--- a/CodeSearcher.Index/Factory.cs
+++ b/CodeSearcher.Index/Factory.cs
@@ -47,6 +47,40 @@ namespace CodeSearcher.BusinessLogic
             return indexer;
         }
 
+        public static ICodeSearcherLogic GetCodeSearcherLogic(
+            ICodeSearcherLogger logger,
+            Func<string> getIndexPath,
+            Func<string> getSourcePath,
+            Func<IList<string>> getFileExtension)
+        {
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            if (getIndexPath is null)
+            {
+                throw new ArgumentNullException(nameof(getIndexPath));
+            }
+
+            if (getSourcePath is null)
+            {
+                throw new ArgumentNullException(nameof(getSourcePath));
+            }
+
+            if (getFileExtension is null)
+            {
+                throw new ArgumentNullException(nameof(getFileExtension));
+            }
+
+            return Ioc.Get<ICodeSearcherLogic>(
+                new ConstructorArgument("logger", logger),
+                new ConstructorArgument("getIndexPath", getIndexPath),
+                new ConstructorArgument("getSourcePath", getSourcePath),
+                new ConstructorArgument("getFileExtension", getFileExtension)
+                );
+        }
+
         public static ISearcher GetSearcher(String pathToIndexFiles)
         {
             if (String.IsNullOrWhiteSpace(pathToIndexFiles)) throw new ArgumentNullException("pathToIndexFiles");
@@ -87,9 +121,15 @@ namespace CodeSearcher.BusinessLogic
             return result;
         }
 
-        internal static IResultExporter GetResultExporter()
+        public static IResultExporter GetResultExporter(StreamWriter exportWriter)
         {
-            return Ioc.Get<IResultExporter>();
+            if (exportWriter is null)
+            {
+                throw new ArgumentNullException(nameof(exportWriter));
+            }
+
+            return Ioc.Get<IResultExporter>(
+                new ConstructorArgument("exportWriter", exportWriter));
         }
 
         internal static Lucene.Net.Store.Directory GetLuceneDirectory(String indexPath)

--- a/CodeSearcher.Index/Ninject/CodeSearcherNinjectModule.cs
+++ b/CodeSearcher.Index/Ninject/CodeSearcherNinjectModule.cs
@@ -19,6 +19,7 @@ namespace CodeSearcher.BusinessLogic.Ninject
             Bind<ISearcher>().To(typeof(DefaultSearcher));
             Bind<IFileReader>().To(typeof(FileReader));
             Bind<IResultExporter>().To<ResultFileExporter>();
+            Bind<ICodeSearcherLogic>().To<CodeSearcherLogic>();
         }
     }
 }

--- a/CodeSearcher.Interfaces/CodeSearcher.Interfaces.csproj
+++ b/CodeSearcher.Interfaces/CodeSearcher.Interfaces.csproj
@@ -60,6 +60,7 @@
   <ItemGroup>
     <Compile Include="EventsAndDelegates.cs" />
     <Compile Include="ICodeSearcherLogger.cs" />
+    <Compile Include="ICodeSearcherLogic.cs" />
     <Compile Include="IIndexer.cs" />
     <Compile Include="IResultExporter.cs" />
     <Compile Include="ISearcher.cs" />

--- a/CodeSearcher.Interfaces/CodeSearcher.Interfaces.csproj
+++ b/CodeSearcher.Interfaces/CodeSearcher.Interfaces.csproj
@@ -59,7 +59,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="EventsAndDelegates.cs" />
-    <Compile Include="ICmdLineHandler.cs" />
     <Compile Include="ICodeSearcherLogger.cs" />
     <Compile Include="IIndexer.cs" />
     <Compile Include="IResultExporter.cs" />

--- a/CodeSearcher.Interfaces/ICodeSearcherLogic.cs
+++ b/CodeSearcher.Interfaces/ICodeSearcherLogic.cs
@@ -7,6 +7,6 @@ namespace CodeSearcher.BusinessLogic
     public interface ICodeSearcherLogic
     {
         void CreateNewIndex(Action startCallback, Action<string> fileProccessedCallback, Action<long, TimeSpan> finishedCallback);
-        void SearchWithinExistingIndex(Action startCallback, Func<(string, bool)> getSearchWord, Func<int> getMaximumNumberOfHits, Func<int> getHitsPerPage, Func<(bool, StreamWriter)> getExporter, Func<ISingleResultPrinter> getSingleResultPrinter, Action<TimeSpan> finishedCallback, Action endOfSearchCallback, Action exportFinishedCallback = null);
+        void SearchWithinExistingIndex(Action startCallback, Func<(string, bool)> getSearchWord, Func<int> getMaximumNumberOfHits, Func<int> getHitsPerPage, Func<(bool, IResultExporter)> getExporter, Func<ISingleResultPrinter> getSingleResultPrinter, Action<TimeSpan> finishedCallback, Action endOfSearchCallback, Action exportFinishedCallback = null);
     }
 }

--- a/CodeSearcher.Interfaces/ICodeSearcherLogic.cs
+++ b/CodeSearcher.Interfaces/ICodeSearcherLogic.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.IO;
+using CodeSearcher.Interfaces;
+
+namespace CodeSearcher.BusinessLogic
+{
+    public interface ICodeSearcherLogic
+    {
+        void CreateNewIndex(Action startCallback, Action<string> fileProccessedCallback, Action<long, TimeSpan> finishedCallback);
+        void SearchWithinExistingIndex(Action startCallback, Func<(string, bool)> getSearchWord, Func<int> getMaximumNumberOfHits, Func<int> getHitsPerPage, Func<(bool, StreamWriter)> getExporter, Func<ISingleResultPrinter> getSingleResultPrinter, Action<TimeSpan> finishedCallback, Action endOfSearchCallback, Action exportFinishedCallback = null);
+    }
+}

--- a/CodeSearcher.Interfaces/IResultExporter.cs
+++ b/CodeSearcher.Interfaces/IResultExporter.cs
@@ -1,7 +1,9 @@
-﻿namespace CodeSearcher.Interfaces
+﻿using System.IO;
+
+namespace CodeSearcher.Interfaces
 {
     public interface IResultExporter
     {
-        void Export(ISearchResultContainer searchResultContainer, string fileName, string searchedWord);
+        void Export(ISearchResultContainer searchResultContainer, string searchedWord, StreamWriter exportWriter);
     } 
 }

--- a/CodeSearcher.Interfaces/IResultExporter.cs
+++ b/CodeSearcher.Interfaces/IResultExporter.cs
@@ -1,9 +1,10 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 
 namespace CodeSearcher.Interfaces
 {
-    public interface IResultExporter
+    public interface IResultExporter : IDisposable
     {
-        void Export(ISearchResultContainer searchResultContainer, string searchedWord, StreamWriter exportWriter);
+        void Export(ISearchResultContainer searchResultContainer, string searchedWord);
     } 
 }

--- a/CodeSearcher/CmdLineHandler.cs
+++ b/CodeSearcher/CmdLineHandler.cs
@@ -78,6 +78,10 @@ namespace CodeSearcher
 
             try
             {
+                for(int i = 0; i < cmdArgs.Length; i++)
+                {
+                    cmdArgs[i] = cmdArgs[i].Trim();
+                }
                 os.Parse(cmdArgs);
             }
             catch (OptionException)
@@ -105,7 +109,7 @@ namespace CodeSearcher
                     }
                     else if (mode == "search" || mode == "s")
                     {
-                        argumentsOk = SetArgumentsForSearching(os, idxPath, searchedWord, numberOfHitsToShow, hitsPerPage);
+                        argumentsOk = SetArgumentsForSearching(os, idxPath, searchedWord, numberOfHitsToShow, hitsPerPage, export);
                     }
                     else
                     {
@@ -155,7 +159,7 @@ namespace CodeSearcher
             return argumentsOk;
         }
 
-        private bool SetArgumentsForSearching(OptionSet os, Variable<string> idxPath, Variable<string> searchedWord, Variable<int> numberOfHitsToShow, Variable<int> hitsPerPage)
+        private bool SetArgumentsForSearching(OptionSet os, Variable<string> idxPath, Variable<string> searchedWord, Variable<int> numberOfHitsToShow, Variable<int> hitsPerPage, Switch export)
         {
             bool argumentsOk = true;
             m_Arguments[ProgramMode] = "search";
@@ -188,6 +192,11 @@ namespace CodeSearcher
                 else
                 {
                     m_Arguments[HitsPerPage] = "-1";
+                }
+
+                if (export.Enabled)
+                {
+                    m_Arguments[ExportToFile] = true.ToString();
                 }
             }
             else

--- a/CodeSearcher/CodeSearcher.csproj
+++ b/CodeSearcher/CodeSearcher.csproj
@@ -78,6 +78,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CmdLineHandler.cs" />
+    <Compile Include="ICmdLineHandler.cs" />
     <Compile Include="LoggerAdapter.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/CodeSearcher/ConsoleResultPrinter.cs
+++ b/CodeSearcher/ConsoleResultPrinter.cs
@@ -32,7 +32,7 @@ namespace CodeSearcher
                 {
                     var line = lines[i].Trim();
                     Console.ForegroundColor = ConsoleColor.Yellow;
-                    Console.Write("line {0}: ", i);
+                    Console.Write("line {0}: ", i+1);
                     Console.ResetColor();
 
                     //TODO handle multiple hits in one line

--- a/CodeSearcher/ICmdLineHandler.cs
+++ b/CodeSearcher/ICmdLineHandler.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 
-namespace CodeSearcher.Interfaces
+namespace CodeSearcher
 {
-    public interface ICmdLineHandler
+    internal interface ICmdLineHandler
     {
         string this[string name] { get; }
 

--- a/CodeSearcherTests/SystemTests/BookCountOfMonteCristoTests.cs
+++ b/CodeSearcherTests/SystemTests/BookCountOfMonteCristoTests.cs
@@ -40,6 +40,62 @@ namespace CodeSearcher.Tests.SystemTests
             }
         }
 
+        #region Test Classes
+
+        private class TestResultExporterAdapter : IResultExporter
+        {
+            private MemoryStream _stream;
+            private IResultExporter _exporter;
+
+            internal TestResultExporterAdapter()
+            {
+                _stream = new MemoryStream();
+                var writer = new StreamWriter(_stream);
+                _exporter = Factory.GetResultExporter(writer);
+                
+            }
+            public void Dispose()
+            {
+                _exporter?.Dispose();
+                _stream?.Close();
+            }
+
+            public void Export(ISearchResultContainer searchResultContainer, string searchedWord)
+            {
+                _exporter.Export(searchResultContainer, searchedWord);
+            }
+
+            internal void Verify()
+            {
+                var reader = new StreamReader(_stream);
+                _stream.Seek(0, SeekOrigin.Begin);
+                int counter = 0;
+                string line;
+                while ((line = reader.ReadLine()) != null)
+                {
+                    counter++;
+
+                    if (counter == 0)
+                    {
+                        Assert.That(line, Is.EqualTo("56;look at the file size will have to do, but we will try to see a"));
+                    }
+
+                    if(counter == 1019)
+                    {
+                        Assert.That(line, Is.EqualTo("34246;old reports, which I was so anxious to put an end to, will"));
+                    }
+
+                    if(counter == 1957)
+                    {
+                        Assert.That(line, Is.EqualTo("62009;\"the count's generosity is too overwhelming; Valentine will"));
+                    }
+                }
+                Assert.That(counter, Is.EqualTo(1957));
+                Assert.That(_stream.Length, Is.EqualTo(121472));
+            }
+        }
+        #endregion
+
         #region Tests
 
         [Test]
@@ -118,6 +174,35 @@ namespace CodeSearcher.Tests.SystemTests
                 endOfSearchCallback: () => { });
 
             exporterStub.VerifyAll();
+        }
+
+        [Test]
+        [Order(4)]
+        [NonParallelizable]
+        public void Test_SearchAndExport_Word_Will()
+        {
+            var logic = GetCodeSearchLogic();
+            string searchWord = "Will";
+
+            var printerStub = new Mock<ISingleResultPrinter>();
+            printerStub.SetupAllProperties();
+
+            var exporter = new TestResultExporterAdapter();
+
+            logic.SearchWithinExistingIndex(
+                startCallback: () => { },
+                getSearchWord: () => { return (searchWord, true); },
+                getMaximumNumberOfHits: () => { return 2000; },
+                getHitsPerPage: () => { return -1; },
+                getExporter: () => { return (true, exporter); },
+                getSingleResultPrinter: () => { return printerStub.Object; },
+                finishedCallback: (timeSpan) => { },
+                endOfSearchCallback: () => { },
+                exportFinishedCallback: () =>
+                {
+                    exporter.Verify();
+                    exporter.Dispose();
+                });
         }
         #endregion
 

--- a/CodeSearcherTests/SystemTests/BookCountOfMonteCristoTests.cs
+++ b/CodeSearcherTests/SystemTests/BookCountOfMonteCristoTests.cs
@@ -47,7 +47,7 @@ namespace CodeSearcher.Tests.SystemTests
         [NonParallelizable]
         public void Test_CreateIndexOfTheCountOfMonteCristo()
         {
-            var logic = GetCodeSearchLogicForIndexing();
+            var logic = GetCodeSearchLogic();
             logic.CreateNewIndex(
                 () => { },
                 (fileName) =>
@@ -65,7 +65,7 @@ namespace CodeSearcher.Tests.SystemTests
         [NonParallelizable]
         public void Test_Search_Word_The()
         {
-            var logic = GetCodeSearchLogicForLookup();
+            var logic = GetCodeSearchLogic();
             string searchWord = "large";
 
             var printerStub = new Mock<ISingleResultPrinter>();
@@ -78,67 +78,29 @@ namespace CodeSearcher.Tests.SystemTests
             );
 
             logic.SearchWithinExistingIndex(
-                () => { },
-                () => { return (searchWord, true); },
-                printerStub.Object,
-                (timeSpan) => { },
-                () => { });
+                startCallback: () => { },
+                getSearchWord: () => { return (searchWord, true); },
+                getMaximumNumberOfHits: () => { return 1000; },
+                getHitsPerPage: () => { return -1; },
+                getExporter: () => { return (false, null); },
+                getSingleResultPrinter: () => { return printerStub.Object; },
+                finishedCallback: (timeSpan) => { },
+                endOfSearchCallback: () => { });
 
             printerStub.VerifyAll();
         }
         #endregion
 
         #region Private Implementation
-        private CodeSearcherLogic GetCodeSearchLogicForLookup()
+        private CodeSearcherLogic GetCodeSearchLogic()
         {
-            Mock<ICmdLineHandler> cmdHandlerStub = GetDefaultCmdLineHandlerStub();
-            cmdHandlerStub.SetupGet(x => x[It.Is<string>(s => s.Equals("ProgramMode"))]).Returns("s");
-
             var loggerStub = new Mock<ICodeSearcherLogger>();
 
             return new CodeSearcherLogic(
-                cmdHandlerStub.Object,
                 loggerStub.Object,
-                () => cmdHandlerStub.Object["IndexPath"],
-                () => cmdHandlerStub.Object["SourcePath"],
+                () => m_IndexFolder,
+                () => m_SourcePath,
                 () => new List<string> { ".txt" });
-        }
-
-        private CodeSearcherLogic GetCodeSearchLogicForIndexing()
-        {
-            Mock<ICmdLineHandler> cmdHandlerStub = GetDefaultCmdLineHandlerStub();
-            cmdHandlerStub.SetupGet(x => x[It.Is<string>(s => s.Equals("ProgramMode"))]).Returns("i");
-            cmdHandlerStub.SetupGet(x => x[It.Is<string>(s => s.Equals("SourcePath"))]).Returns(m_SourcePath);
-
-            var loggerStub = new Mock<ICodeSearcherLogger>();
-
-            return new CodeSearcherLogic(
-                cmdHandlerStub.Object,
-                loggerStub.Object,
-                () => cmdHandlerStub.Object["IndexPath"],
-                () => cmdHandlerStub.Object["SourcePath"],
-                () => new List<string> { ".txt" });
-        }
-
-        private Mock<ICmdLineHandler> GetDefaultCmdLineHandlerStub()
-        {
-            var cmdHandlerStub = new Mock<ICmdLineHandler>();
-            cmdHandlerStub.SetupGet(x => x.ExportToFile).Returns("ExportToFile");
-            cmdHandlerStub.SetupGet(x => x.FileExtensions).Returns("FileExtensions");
-            cmdHandlerStub.SetupGet(x => x.HitsPerPage).Returns("HitsPerPage");
-            cmdHandlerStub.SetupGet(x => x.IndexPath).Returns("IndexPath");
-            cmdHandlerStub.SetupGet(x => x.NumberOfHits).Returns("NumberOfHits");
-            cmdHandlerStub.SetupGet(x => x.ProgramMode).Returns("ProgramMode");
-            cmdHandlerStub.SetupGet(x => x.SearchedWord).Returns("SearchedWord");
-            cmdHandlerStub.SetupGet(x => x.SourcePath).Returns("SourcePath");
-
-            cmdHandlerStub.SetupGet(x => x[It.Is<string>(s => s.Equals("NumberOfHits"))]).Returns("1000");
-            cmdHandlerStub.SetupGet(x => x[It.Is<string>(s => s.Equals("IndexPath"))]).Returns(m_IndexFolder);
-            //cmdHandlerStub.SetupGet(x => x[It.Is<string>(s => s.Equals("IndexPath"))]).Returns(@"C:\test\index");
-            cmdHandlerStub.SetupGet(x => x[It.Is<string>(s => s.Equals("FileExtensions"))]).Returns(".txt");
-
-
-            return cmdHandlerStub;
         }
         #endregion
     }

--- a/CodeSearcherTests/SystemTests/BookCountOfMonteCristoTests.cs
+++ b/CodeSearcherTests/SystemTests/BookCountOfMonteCristoTests.cs
@@ -63,7 +63,7 @@ namespace CodeSearcher.Tests.SystemTests
         [Test]
         [Order(2)]
         [NonParallelizable]
-        public void Test_Search_Word_The()
+        public void Test_Search_Word_Large()
         {
             var logic = GetCodeSearchLogic();
             string searchWord = "large";
@@ -89,14 +89,44 @@ namespace CodeSearcher.Tests.SystemTests
 
             printerStub.VerifyAll();
         }
+
+        [Test]
+        [Order(3)]
+        [NonParallelizable]
+        public void Test_SearchAndExport_Word_The()
+        {
+            var logic = GetCodeSearchLogic();
+            string searchWord = "the";
+
+            var printerStub = new Mock<ISingleResultPrinter>();
+            printerStub.SetupAllProperties();
+
+            var exporterStub = new Mock<IResultExporter>();
+            exporterStub.Setup(x => x.Export(
+                It.IsAny<ISearchResultContainer>(),
+                It.Is<string>(
+                    s => s.Equals("the"))));
+
+            logic.SearchWithinExistingIndex(
+                startCallback: () => { },
+                getSearchWord: () => { return (searchWord, true); },
+                getMaximumNumberOfHits: () => { return 1000; },
+                getHitsPerPage: () => { return -1; },
+                getExporter: () => { return (true, exporterStub.Object); },
+                getSingleResultPrinter: () => { return printerStub.Object; },
+                finishedCallback: (timeSpan) => { },
+                endOfSearchCallback: () => { });
+
+            exporterStub.VerifyAll();
+        }
         #endregion
 
         #region Private Implementation
-        private CodeSearcherLogic GetCodeSearchLogic()
+        private ICodeSearcherLogic GetCodeSearchLogic()
         {
             var loggerStub = new Mock<ICodeSearcherLogger>();
 
-            return new CodeSearcherLogic(
+            return Factory.GetCodeSearcherLogic(
                 loggerStub.Object,
                 () => m_IndexFolder,
                 () => m_SourcePath,


### PR DESCRIPTION
# New Feature

Export of finding results.

## Description 
Instead of logging results to console it is now possible to create a temporary file with all findings.

## Usage
```cmd
CodeSearcher.exe -m=s -ip=<PathToIndex> -sw=<WordToSearch> -e
```
To activate new feature add **-e** or **--export** as command line switch.

## Result
The command line Output contains path to temporary file with exported Content:
```cmd
Export file written: C:\Users\<User>\AppData\Local\Temp\tmp58EA.tmp
```

### Format of Export File
FileName
lineNumber;LineContent
lineNumber;LineContent