### PR TITLE
Start the correct profile

### DIFF
--- a/CodeSearcher.WebAPI/Properties/launchSettings.json
+++ b/CodeSearcher.WebAPI/Properties/launchSettings.json
@@ -9,14 +9,6 @@
   },
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "launchUrl": "weatherforecast",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
     "CodeSearcher.WebAPI": {
       "commandName": "Project",
       "launchBrowser": true,


### PR DESCRIPTION
Removed the launch profile(weatherforecast) from the launchsettings.json inherited by the project template. It interfered with debug start from within VS2019.