### PR TITLE
Dedicated API endpoint for list of indexes

### DIFF
--- a/CodeSearcher.Index/Common/Names.cs
+++ b/CodeSearcher.Index/Common/Names.cs
@@ -24,7 +24,7 @@ namespace CodeSearcher.BusinessLogic.Common
     /// <summary>
     /// Class contain constants for well know folder names
     /// </summary>
-    internal static class FolderNames
+    public static class FolderNames
     {
         /// <summary>
         /// Name of the folder, that is used to store lucene files, when using CodeSearcherManager

--- a/CodeSearcher.Interfaces/Constants/APIRoutes.cs
+++ b/CodeSearcher.Interfaces/Constants/APIRoutes.cs
@@ -21,6 +21,11 @@
         public const string CodeSearcherRoute = "/api/CodeSearcher";
 
         /// <summary>
+        /// Base route to access CodeSearchers list of indexes
+        /// </summary>
+        public const string IndexListRoute = "/api/CodeSearcher/indexList";
+
+        /// <summary>
         /// Route to read and update Code Searcher configuration
         /// </summary>
         public const string ConfigurationRoute = "/api/CodeSearcher/configure";

--- a/CodeSearcher.WebAPI.Tests/BasicWebAPITests.cs
+++ b/CodeSearcher.WebAPI.Tests/BasicWebAPITests.cs
@@ -44,11 +44,20 @@ namespace CodeSearcher.WebAPI.Tests
         }
 
         [Test]
-        [Order(1)]
-        public async Task Test_Route_Expect_200OK()
+        [Order(0)]
+        public async Task Test_Route_for_RootPath_Expect_200OK()
         {
             using var client = m_TestServer.CreateClient();
             using var response = await client.GetAsync(APIRoutes.CodeSearcherRoute);
+            response.EnsureSuccessStatusCode();
+        }
+
+        [Test]
+        [Order(1)]
+        public async Task Test_Route_for_SearchIndexeList_Expect_200OK()
+        {
+            using var client = m_TestServer.CreateClient();
+            using var response = await client.GetAsync(APIRoutes.IndexListRoute);
             response.EnsureSuccessStatusCode();
         }
 

--- a/CodeSearcher.WebAPI.Tests/ComplexeWebAPITests.cs
+++ b/CodeSearcher.WebAPI.Tests/ComplexeWebAPITests.cs
@@ -1,4 +1,6 @@
 ﻿using CodeSearcher.BusinessLogic;
+using CodeSearcher.BusinessLogic.Common;
+using CodeSearcher.Interfaces;
 using CodeSearcher.Interfaces.API.Model.Requests;
 using CodeSearcher.Interfaces.API.Model.Response;
 using CodeSearcher.Interfaces.Constants;
@@ -14,6 +16,21 @@ using System.Threading.Tasks;
 
 namespace CodeSearcher.WebAPI.Tests
 {
+    class VoidLogger : ICodeSearcherLogger
+    {
+        public void Debug(string message, params object[] parameter)
+        {
+        }
+
+        public void Error(string message, params object[] parameter)
+        {
+        }
+
+        public void Info(string message, params object[] parameter)
+        {
+        }
+    }
+
     [TestFixture]
     [Category("NotSafeForCI")]
     [Order(500)]
@@ -24,11 +41,26 @@ namespace CodeSearcher.WebAPI.Tests
         [SetUp]
         public void SetUp()
         {
+
+
+            var manager = Factory.Get().GetCodeSearcherManager(new VoidLogger());
+            var managementInformationTestPath = Path.Combine(WebTestHelper.GetPathToTestData("AppData"), FolderNames.ManagementFolder);
+            if (!Directory.Exists(managementInformationTestPath))
+            {
+                Directory.CreateDirectory(managementInformationTestPath);
+            }
+            manager.ManagementInformationPath = managementInformationTestPath;
+
             var builder = new WebHostBuilder()
                 .UseEnvironment("Development")
                 .UseStartup<CodeSearcher.WebAPI.Startup>();
-
             m_TestServer = new TestServer(builder);
+
+            var metaPath = WebTestHelper.GetPathToTestData("Meta");
+            if (Directory.Exists(metaPath))
+            {
+                Directory.Delete(metaPath, true);
+            }
         }
 
         [TearDown]
@@ -42,7 +74,12 @@ namespace CodeSearcher.WebAPI.Tests
             {
                 Directory.Delete(metaPath, true);
             }
-         }
+            var managementInformationTestPath = Path.Combine(WebTestHelper.GetPathToTestData("AppData"), FolderNames.ManagementFolder);
+            if (Directory.Exists(managementInformationTestPath))
+            {
+                Directory.Delete(managementInformationTestPath, true);
+            }
+        }
 
         [Test]
         public async Task Test_DeleteIndex_Expect_Success()
@@ -67,27 +104,26 @@ namespace CodeSearcher.WebAPI.Tests
             }
 
             //TODO can be optimized with API method to get information if background job still running
-            GetIndexesResponse indexesModel;
+            ICodeSearcherIndex[] indexesModel;
             int count = 0;
             do
             {
-                using (var response = await client.GetAsync(APIRoutes.CodeSearcherRoute))
+                using (var response = await client.GetAsync(APIRoutes.IndexListRoute))
                 {
                     var responsePayload = await response.Content.ReadAsStringAsync();
                     var settings = new JsonSerializerSettings();
                     settings.Converters.Add(Factory.Get().GetCodeSearcherIndexJsonConverter());
-                    indexesModel = JsonConvert.DeserializeObject<GetIndexesResponse>(responsePayload, settings);
+                    indexesModel = JsonConvert.DeserializeObject<ICodeSearcherIndex[]>(responsePayload, settings);
                     Assert.That(indexesModel, Is.Not.Null);
-                    Assert.That(indexesModel.Indexes, Is.Not.Null);
                 }
                 await Task.Delay(250);
                 //timeout
                 Assert.That(count++, Is.LessThan(100));
-            } while (indexesModel.Indexes.Length < 1);
+            } while (indexesModel.Length < 1);
 
             var deleteRequestModel = new DeleteIndexRequest
             {
-                IndexID = indexesModel.Indexes[0].ID
+                IndexID = indexesModel[0].ID
             };
 
             // simplified API client.DeleteAsync doesn't allow to set content
@@ -129,27 +165,26 @@ namespace CodeSearcher.WebAPI.Tests
             {
             }
 
-            GetIndexesResponse indexesModel;
+            ICodeSearcherIndex[] indexesModel;
             int count = 0;
             do
             {
-                using (var response = await client.GetAsync(APIRoutes.CodeSearcherRoute))
+                using (var response = await client.GetAsync(APIRoutes.IndexListRoute))
                 {
                     var responsePayload = await response.Content.ReadAsStringAsync();
                     var settings = new JsonSerializerSettings();
                     settings.Converters.Add(Factory.Get().GetCodeSearcherIndexJsonConverter());
-                    indexesModel = JsonConvert.DeserializeObject<GetIndexesResponse>(responsePayload, settings);
+                    indexesModel = JsonConvert.DeserializeObject<ICodeSearcherIndex[]>(responsePayload, settings);
                     Assert.That(indexesModel, Is.Not.Null);
-                    Assert.That(indexesModel.Indexes, Is.Not.Null);
                 }
                 await Task.Delay(250);
                 //timeout
                 Assert.That(count++, Is.LessThan(100));
-            } while (indexesModel.Indexes.Length < 1);
+            } while (indexesModel.Length < 1);
 
             var searchModel = new SearchIndexRequest()
             {
-                IndexID = indexesModel.Indexes[0].ID,
+                IndexID = indexesModel[0].ID,
                 SearchWord = "erat"
             };
             using (var requestPayload = new StringContent(JsonConvert.SerializeObject(searchModel), Encoding.UTF8, "application/json"))
@@ -160,15 +195,16 @@ namespace CodeSearcher.WebAPI.Tests
                     Content = requestPayload,
                     RequestUri = new Uri(client.BaseAddress, APIRoutes.SearchInIndexRoute)
                 };
+                using (var response = await client.SendAsync(request))
+                {
+                    response.EnsureSuccessStatusCode();
 
-                using var response = await client.SendAsync(request);
-                response.EnsureSuccessStatusCode();
-
-                var responsePayload = await response.Content.ReadAsStringAsync();
-                var settings = new JsonSerializerSettings();
-                settings.Converters.Add(Factory.Get().GetDetailedResultJsonConverter());
-                settings.Converters.Add(Factory.Get().GetFindingsInFileJsonConverter());
-                var searchIndex = JsonConvert.DeserializeObject<SearchIndexResponse>(responsePayload, settings);
+                    var responsePayload = await response.Content.ReadAsStringAsync();
+                    var settings = new JsonSerializerSettings();
+                    settings.Converters.Add(Factory.Get().GetDetailedResultJsonConverter());
+                    settings.Converters.Add(Factory.Get().GetFindingsInFileJsonConverter());
+                    var searchIndex = JsonConvert.DeserializeObject<SearchIndexResponse>(responsePayload, settings);
+                }
             }
         }
     }

--- a/CodeSearcher.WebAPI/CodeSearcher.WebAPI.csproj
+++ b/CodeSearcher.WebAPI/CodeSearcher.WebAPI.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="HangFire" Version="1.7.11" />
     <PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.6" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.5.1" />
   </ItemGroup>

--- a/CodeSearcher.WebAPI/Controllers/CodeSearcherController.cs
+++ b/CodeSearcher.WebAPI/Controllers/CodeSearcherController.cs
@@ -47,7 +47,7 @@ namespace CodeSearcher.WebAPI.Controllers
                 }
             }
         }
-        
+
         /// <summary>
         /// Read Read all existing indexes
         /// </summary>
@@ -61,7 +61,7 @@ namespace CodeSearcher.WebAPI.Controllers
         /// </remarks>
         /// <returns>Enumeration of existing indexes, maybe empty enumeration <see cref="GetIndexesResponse"/></returns>
         [HttpGet("")]
-        public ActionResult<GetIndexesResponse> GetAllIndexes()
+        public ActionResult<GetIndexesResponse> GetRoot()
         {
             m_Logger.Info($"[GET] {APIRoutes.CodeSearcherRoute} (GetAllIndexes)");
             var indexes = m_Manager.GetAllIndexes();
@@ -69,6 +69,26 @@ namespace CodeSearcher.WebAPI.Controllers
             {
                 Indexes = indexes.ToArray()
             };
+        }
+
+        /// <summary>
+        /// Read all existing indexes
+        /// </summary>
+        /// <remarks>
+        /// Sample request:
+        /// 
+        ///     GET /api/CodeSearcher/indexList
+        ///     {
+        ///     }
+        ///     
+        /// </remarks>
+        /// <returns>Array of existing indexes, maybe empty Array <see cref="ICodeSearcherIndex"/></returns>
+        [HttpGet("indexList")]
+        public ActionResult<ICodeSearcherIndex[]> GetAllIndexes()
+        {
+            m_Logger.Info($"[GET] {APIRoutes.IndexListRoute} (GetAllIndexes)");
+            var indexes = m_Manager.GetAllIndexes();
+            return  indexes.ToArray();
         }
 
         /// <summary>

--- a/CodeSearcherTests/AddThisToPostBuildEvent.txt
+++ b/CodeSearcherTests/AddThisToPostBuildEvent.txt
@@ -1,1 +1,5 @@
-﻿start XCOPY /Y /s /d $(ProjectDir)SystemTests\DownloadedTestData $(TargetDir)SystemTests\DownloadedTestData\
+﻿IF EXIST $(ProjectDir)SystemTests\DownloadedTestData (
+    start XCOPY /Y /s /d $(ProjectDir)SystemTests\DownloadedTestData $(TargetDir)SystemTests\DownloadedTestData\
+) ELSE (
+    echo ERROR: TestData for system test does not exit! Please call CreateTestEnvironment.ps1 once on your development PC.
+)


### PR DESCRIPTION
Change API to have a dedicated endpoint for getting the list of indexes. This makes it easier for clients to use the data without creating a overcomplicated object hierarchy.

Make tests run without trashing the users AppData of a local CodeSearcher instance. The test now uses a AppData folder within the test infra structure.

Extend SystemTest post build event handling with a error mesage in case the test data was not available. This cost me 1h to figure out why my tests where red ...